### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
     "version"     : "*",
     "author"      : "Andy Weidenbaum",
     "description" : "TOML file parser and writer",
-    "license"     : "http://unlicense.org/UNLICENSE",
+    "license"     : "Unlicense",
     "depends"     : ["Crane"],
     "source-type" : "git",
     "source-url"  : "git://github.com/atweiden/config-toml.git",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license