### PR TITLE
Change to-toml to no longer use .perl

### DIFF
--- a/lib/Config/TOML/Dumper.pm
+++ b/lib/Config/TOML/Dumper.pm
@@ -194,7 +194,7 @@ multi sub is-valid-array(@ --> Bool:D)
 
 multi sub to-toml(Str:D $s --> Str:D)
 {
-    $s.perl;
+    '"' ~ $s ~ '"';
 }
 
 multi sub to-toml(Str:U $s)

--- a/lib/Config/TOML/Dumper.pm
+++ b/lib/Config/TOML/Dumper.pm
@@ -194,7 +194,7 @@ multi sub is-valid-array(@ --> Bool:D)
 
 multi sub to-toml(Str:D $s --> Str:D)
 {
-    '"' ~ $s ~ '"';
+    '"' ~ $s.subst('"', '\"', :g) ~ '"';
 }
 
 multi sub to-toml(Str:U $s)


### PR DESCRIPTION
This resulted in incorrect TOML when used with an email address, as it
would escape the @ inside the string.