### PR TITLE
Fix a test

### DIFF
--- a/t/exceptions/02-dumper.t
+++ b/t/exceptions/02-dumper.t
@@ -260,8 +260,8 @@ subtest({
     lives-ok({ to-toml(%valid) }, 'Valid array is valid');
     throws-like(
         { to-toml(%invalid) },
-        X::Config::TOML::Dumper::BadValue,
-        :message('Sorry, undefined Bool types cannot be represented as TOML keypair value'),
+        X::Config::TOML::Dumper::BadArray,
+        :message(/^ 'Sorry, invalid TOML array.'/),
         'Raise exception when array contains undefined values'
     );
     (%valid, %invalid) = Empty;


### PR DESCRIPTION
It was previously passing due to a bug in Rakudo which allowed `Bool ~~ Bool:D` to be true.

The exception currently thrown by `Config::TOML::Dumper` is actually the right one for this test because the array doesn't pass validation.